### PR TITLE
Fix responsive Jotform embeds

### DIFF
--- a/404.html
+++ b/404.html
@@ -123,22 +123,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -244,11 +289,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/about.html
+++ b/about.html
@@ -163,22 +163,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -284,11 +329,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4788,3 +4788,28 @@ section,
 .starter-section {
   /* Add your styles here */
 }
+/*--------------------------------------------------------------
+# Jotform Responsive Overrides
+--------------------------------------------------------------*/
+#contacto .card,
+#contacto .card-body {
+  overflow: visible;
+}
+
+@media (max-width: 576px) {
+  #JotFormIFrame-252685821114355 {
+    min-height: 1300px;
+  }
+}
+
+.whatsapp-float {
+  right: 16px;
+  bottom: 24px;
+  z-index: 1030;
+}
+
+@media (max-width: 576px) {
+  .whatsapp-float {
+    bottom: 88px;
+  }
+}

--- a/como-funciona.html
+++ b/como-funciona.html
@@ -113,18 +113,63 @@
             </div>
           </div>
           <div class="col-lg-6">
-            <div class="card border-0 shadow-lg">
-              <div class="card-body p-4" id="contacto">
+            <div class="card border-0 shadow-lg overflow-visible">
+              <div class="card-body p-4 overflow-visible" id="contacto">
                 <h3 class="h4 mb-3">¿Hablamos ahora?</h3>
                 <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-                <!-- Jotform -->
-                <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-                  <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-                  <noscript>
-                    <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-                  </noscript>
-                </div>
+                <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+                <iframe
+                  id="JotFormIFrame-252685821114355"
+                  title="Formulario de contacto"
+                  allowtransparency="true"
+                  allow="geolocation; microphone; camera"
+                  src="https://form.jotform.com/252685821114355"
+                  style="width:100%; min-height: 1100px; border:0; display:block;"
+                  scrolling="no">
+                </iframe>
+
+                <noscript>
+                  <iframe
+                    title="Formulario de contacto (fallback)"
+                    src="https://form.jotform.com/252685821114355"
+                    style="width:100%; height:1400px; border:0;">
+                  </iframe>
+                </noscript>
+
+                <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+                <script>
+                (function () {
+                  var ifr = document.getElementById('JotFormIFrame-252685821114355');
+                  function setHeight(h){
+                    if(!ifr) return;
+                    var px = parseInt(h,10);
+                    if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+                  }
+                  window.addEventListener('message', function(e){
+                    try{
+                      var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                      // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                      if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                        setHeight(data.height || (data.value && data.value.height));
+                      } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                        var parts = e.data.split(':');
+                        setHeight(parts[1]);
+                      }
+                      // Scroll into view if Jotform requests it
+                      if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                        ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                      }
+                    }catch(err){/* ignore */}
+                  });
+
+                  // Safety resize on orientation change / resize
+                  ['orientationchange','resize'].forEach(function(ev){
+                    window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+                  });
+                })();
+                </script>
+
 
                 <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
               </div>
@@ -230,11 +275,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/contact.html
+++ b/contact.html
@@ -129,7 +129,7 @@
                 <div class="icon-container">
                   <i class="bi bi-clock-history"></i>
                 </div>
-                <div class="card-content">
+                <div class="card-content overflow-visible">
                   <h4>Working Hours</h4>
                   <p>Monday-Saturday: 9AM - 7PM</p>
                 </div>
@@ -157,13 +157,58 @@
               <h3 class="h4 mb-3">¿Hablamos ahora?</h3>
               <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-              <!-- Jotform -->
-              <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-                <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-                <noscript>
-                  <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-                </noscript>
-              </div>
+              <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+              <iframe
+                id="JotFormIFrame-252685821114355"
+                title="Formulario de contacto"
+                allowtransparency="true"
+                allow="geolocation; microphone; camera"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; min-height: 1100px; border:0; display:block;"
+                scrolling="no">
+              </iframe>
+
+              <noscript>
+                <iframe
+                  title="Formulario de contacto (fallback)"
+                  src="https://form.jotform.com/252685821114355"
+                  style="width:100%; height:1400px; border:0;">
+                </iframe>
+              </noscript>
+
+              <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+              <script>
+              (function () {
+                var ifr = document.getElementById('JotFormIFrame-252685821114355');
+                function setHeight(h){
+                  if(!ifr) return;
+                  var px = parseInt(h,10);
+                  if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+                }
+                window.addEventListener('message', function(e){
+                  try{
+                    var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                    // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                    if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                      setHeight(data.height || (data.value && data.value.height));
+                    } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                      var parts = e.data.split(':');
+                      setHeight(parts[1]);
+                    }
+                    // Scroll into view if Jotform requests it
+                    if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                      ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                    }
+                  }catch(err){/* ignore */}
+                });
+
+                // Safety resize on orientation change / resize
+                ['orientationchange','resize'].forEach(function(ev){
+                  window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+                });
+              })();
+              </script>
+
 
               <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
             </div>
@@ -271,11 +316,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -82,18 +82,63 @@
             </div>
           </div>
           <div class="col-lg-6" data-aos="fade-left" data-aos-delay="300">
-            <div class="card shadow-lg border-0">
-              <div class="card-body p-4" id="contacto">
+            <div class="card shadow-lg border-0 overflow-visible">
+              <div class="card-body p-4 overflow-visible" id="contacto">
                 <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
                 <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-                <!-- Jotform -->
-                <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-                  <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-                  <noscript>
-                    <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-                  </noscript>
-                </div>
+                <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+                <iframe
+                  id="JotFormIFrame-252685821114355"
+                  title="Formulario de contacto"
+                  allowtransparency="true"
+                  allow="geolocation; microphone; camera"
+                  src="https://form.jotform.com/252685821114355"
+                  style="width:100%; min-height: 1100px; border:0; display:block;"
+                  scrolling="no">
+                </iframe>
+
+                <noscript>
+                  <iframe
+                    title="Formulario de contacto (fallback)"
+                    src="https://form.jotform.com/252685821114355"
+                    style="width:100%; height:1400px; border:0;">
+                  </iframe>
+                </noscript>
+
+                <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+                <script>
+                (function () {
+                  var ifr = document.getElementById('JotFormIFrame-252685821114355');
+                  function setHeight(h){
+                    if(!ifr) return;
+                    var px = parseInt(h,10);
+                    if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+                  }
+                  window.addEventListener('message', function(e){
+                    try{
+                      var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                      // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                      if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                        setHeight(data.height || (data.value && data.value.height));
+                      } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                        var parts = e.data.split(':');
+                        setHeight(parts[1]);
+                      }
+                      // Scroll into view if Jotform requests it
+                      if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                        ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                      }
+                    }catch(err){/* ignore */}
+                  });
+
+                  // Safety resize on orientation change / resize
+                  ['orientationchange','resize'].forEach(function(ev){
+                    window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+                  });
+                })();
+                </script>
+
 
                 <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
               </div>
@@ -415,11 +460,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/por-que-vender-piso-okupado.html
+++ b/por-que-vender-piso-okupado.html
@@ -107,18 +107,63 @@
             </ul>
           </div>
           <div class="col-lg-6">
-            <div class="card border-0 shadow-lg">
-              <div class="card-body p-4" id="contacto">
+            <div class="card border-0 shadow-lg overflow-visible">
+              <div class="card-body p-4 overflow-visible" id="contacto">
                 <h3 class="h4 mb-3">¿Hablamos ahora?</h3>
                 <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-                <!-- Jotform -->
-                <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-                  <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-                  <noscript>
-                    <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-                  </noscript>
-                </div>
+                <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+                <iframe
+                  id="JotFormIFrame-252685821114355"
+                  title="Formulario de contacto"
+                  allowtransparency="true"
+                  allow="geolocation; microphone; camera"
+                  src="https://form.jotform.com/252685821114355"
+                  style="width:100%; min-height: 1100px; border:0; display:block;"
+                  scrolling="no">
+                </iframe>
+
+                <noscript>
+                  <iframe
+                    title="Formulario de contacto (fallback)"
+                    src="https://form.jotform.com/252685821114355"
+                    style="width:100%; height:1400px; border:0;">
+                  </iframe>
+                </noscript>
+
+                <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+                <script>
+                (function () {
+                  var ifr = document.getElementById('JotFormIFrame-252685821114355');
+                  function setHeight(h){
+                    if(!ifr) return;
+                    var px = parseInt(h,10);
+                    if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+                  }
+                  window.addEventListener('message', function(e){
+                    try{
+                      var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                      // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                      if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                        setHeight(data.height || (data.value && data.value.height));
+                      } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                        var parts = e.data.split(':');
+                        setHeight(parts[1]);
+                      }
+                      // Scroll into view if Jotform requests it
+                      if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                        ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                      }
+                    }catch(err){/* ignore */}
+                  });
+
+                  // Safety resize on orientation change / resize
+                  ['orientationchange','resize'].forEach(function(ev){
+                    window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+                  });
+                })();
+                </script>
+
 
                 <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
               </div>
@@ -224,11 +269,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/preguntas-frecuentes.html
+++ b/preguntas-frecuentes.html
@@ -148,22 +148,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -301,11 +346,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -207,22 +207,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -328,11 +373,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/project-details.html
+++ b/project-details.html
@@ -284,22 +284,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -405,11 +450,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/projects.html
+++ b/projects.html
@@ -332,22 +332,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -453,11 +498,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/quien-compra-pisos-ocupados.html
+++ b/quien-compra-pisos-ocupados.html
@@ -113,18 +113,63 @@
             </ul>
           </div>
           <div class="col-lg-6">
-            <div class="card border-0 shadow-lg">
-              <div class="card-body p-4" id="contacto">
+            <div class="card border-0 shadow-lg overflow-visible">
+              <div class="card-body p-4 overflow-visible" id="contacto">
                 <h3 class="h4 mb-3">¿Hablamos ahora?</h3>
                 <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-                <!-- Jotform -->
-                <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-                  <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-                  <noscript>
-                    <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-                  </noscript>
-                </div>
+                <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+                <iframe
+                  id="JotFormIFrame-252685821114355"
+                  title="Formulario de contacto"
+                  allowtransparency="true"
+                  allow="geolocation; microphone; camera"
+                  src="https://form.jotform.com/252685821114355"
+                  style="width:100%; min-height: 1100px; border:0; display:block;"
+                  scrolling="no">
+                </iframe>
+
+                <noscript>
+                  <iframe
+                    title="Formulario de contacto (fallback)"
+                    src="https://form.jotform.com/252685821114355"
+                    style="width:100%; height:1400px; border:0;">
+                  </iframe>
+                </noscript>
+
+                <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+                <script>
+                (function () {
+                  var ifr = document.getElementById('JotFormIFrame-252685821114355');
+                  function setHeight(h){
+                    if(!ifr) return;
+                    var px = parseInt(h,10);
+                    if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+                  }
+                  window.addEventListener('message', function(e){
+                    try{
+                      var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                      // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                      if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                        setHeight(data.height || (data.value && data.value.height));
+                      } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                        var parts = e.data.split(':');
+                        setHeight(parts[1]);
+                      }
+                      // Scroll into view if Jotform requests it
+                      if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                        ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                      }
+                    }catch(err){/* ignore */}
+                  });
+
+                  // Safety resize on orientation change / resize
+                  ['orientationchange','resize'].forEach(function(ev){
+                    window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+                  });
+                })();
+                </script>
+
 
                 <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
               </div>
@@ -230,11 +275,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/quote.html
+++ b/quote.html
@@ -151,13 +151,58 @@
                       <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
                     </div>
 
-                    <!-- Jotform -->
-                    <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-                      <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-                      <noscript>
-                        <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-                      </noscript>
-                    </div>
+                    <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+                    <iframe
+                      id="JotFormIFrame-252685821114355"
+                      title="Formulario de contacto"
+                      allowtransparency="true"
+                      allow="geolocation; microphone; camera"
+                      src="https://form.jotform.com/252685821114355"
+                      style="width:100%; min-height: 1100px; border:0; display:block;"
+                      scrolling="no">
+                    </iframe>
+
+                    <noscript>
+                      <iframe
+                        title="Formulario de contacto (fallback)"
+                        src="https://form.jotform.com/252685821114355"
+                        style="width:100%; height:1400px; border:0;">
+                      </iframe>
+                    </noscript>
+
+                    <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+                    <script>
+                    (function () {
+                      var ifr = document.getElementById('JotFormIFrame-252685821114355');
+                      function setHeight(h){
+                        if(!ifr) return;
+                        var px = parseInt(h,10);
+                        if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+                      }
+                      window.addEventListener('message', function(e){
+                        try{
+                          var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                          // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                          if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                            setHeight(data.height || (data.value && data.value.height));
+                          } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                            var parts = e.data.split(':');
+                            setHeight(parts[1]);
+                          }
+                          // Scroll into view if Jotform requests it
+                          if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                            ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                          }
+                        }catch(err){/* ignore */}
+                      });
+
+                      // Safety resize on orientation change / resize
+                      ['orientationchange','resize'].forEach(function(ev){
+                        window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+                      });
+                    })();
+                    </script>
+
 
                     <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
                   </div>
@@ -270,11 +315,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/service-details.html
+++ b/service-details.html
@@ -350,22 +350,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -471,11 +516,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/services.html
+++ b/services.html
@@ -198,22 +198,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -319,11 +364,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/situacion-legal-okupacion.html
+++ b/situacion-legal-okupacion.html
@@ -106,8 +106,8 @@
             </ul>
           </div>
           <div class="col-lg-6">
-            <div class="card border-0 shadow-lg">
-              <div class="card-body p-4">
+            <div class="card border-0 shadow-lg overflow-visible">
+              <div class="card-body p-4 overflow-visible">
                 <h3 class="h4">Evita la espera con una venta inmediata</h3>
                 <p>Firmar con VendeTuPisoOcupado implica recibir tu dinero en 48 horas y olvidarte de procesos inciertos. Nos hacemos cargo de la ocupación y continuamos los trámites en tu lugar.</p>
                 <a href="https://wa.me/34695416518?text=Quiero%20una%20oferta%20por%20mi%20piso%20ocupado" class="btn btn-primary btn-lg">Solicita asesoramiento legal</a>
@@ -141,22 +141,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -245,11 +290,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/starter-page.html
+++ b/starter-page.html
@@ -100,22 +100,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -221,11 +266,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/team.html
+++ b/team.html
@@ -334,22 +334,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -455,11 +500,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/terms.html
+++ b/terms.html
@@ -224,22 +224,67 @@
 
   </main>
 
-  <!-- CONTACTO: Jotform Embed -->
+  <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
   <div id="contacto" class="container my-5">
     <div class="row justify-content-center">
       <div class="col-lg-8">
-        <div class="card shadow-sm border-0">
+        <div class="card shadow-sm border-0 overflow-visible">
           <div class="card-body p-4">
             <h2 class="h4 mb-3">¿Hablamos ahora?</h2>
             <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-            <!-- Jotform -->
-            <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-              <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-              <noscript>
-                <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-              </noscript>
-            </div>
+            <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+            <iframe
+              id="JotFormIFrame-252685821114355"
+              title="Formulario de contacto"
+              allowtransparency="true"
+              allow="geolocation; microphone; camera"
+              src="https://form.jotform.com/252685821114355"
+              style="width:100%; min-height: 1100px; border:0; display:block;"
+              scrolling="no">
+            </iframe>
+
+            <noscript>
+              <iframe
+                title="Formulario de contacto (fallback)"
+                src="https://form.jotform.com/252685821114355"
+                style="width:100%; height:1400px; border:0;">
+              </iframe>
+            </noscript>
+
+            <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+            <script>
+            (function () {
+              var ifr = document.getElementById('JotFormIFrame-252685821114355');
+              function setHeight(h){
+                if(!ifr) return;
+                var px = parseInt(h,10);
+                if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+              }
+              window.addEventListener('message', function(e){
+                try{
+                  var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                  // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                  if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                    setHeight(data.height || (data.value && data.value.height));
+                  } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                    var parts = e.data.split(':');
+                    setHeight(parts[1]);
+                  }
+                  // Scroll into view if Jotform requests it
+                  if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                    ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                  }
+                }catch(err){/* ignore */}
+              });
+
+              // Safety resize on orientation change / resize
+              ['orientationchange','resize'].forEach(function(ev){
+                window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+              });
+            })();
+            </script>
+
 
             <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
           </div>
@@ -345,11 +390,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>

--- a/vender-piso-ocupado-madrid.html
+++ b/vender-piso-ocupado-madrid.html
@@ -97,18 +97,63 @@
             </ul>
           </div>
           <div class="col-lg-4">
-            <div class="card border-0 shadow-lg">
-              <div class="card-body p-4" id="contacto">
+            <div class="card border-0 shadow-lg overflow-visible">
+              <div class="card-body p-4 overflow-visible" id="contacto">
                 <h3 class="h4 mb-3">¿Hablamos ahora?</h3>
                 <p class="mb-4">Completa el formulario y te damos <strong>tasación gratis</strong> y <strong>oferta en 24h</strong>.</p>
 
-                <!-- Jotform -->
-                <div class="ratio ratio-16x9 mb-3" id="jotform-wrapper">
-                  <script type="text/javascript" src="https://form.jotform.com/jsform/252685821114355" defer></script>
-                  <noscript>
-                    <iframe title="Formulario de contacto" src="https://form.jotform.com/252685821114355" style="width:100%;height:700px;border:0;"></iframe>
-                  </noscript>
-                </div>
+                <!-- CONTACTO · JOTFORM (RESPONSIVE/FULL HEIGHT) -->
+                <iframe
+                  id="JotFormIFrame-252685821114355"
+                  title="Formulario de contacto"
+                  allowtransparency="true"
+                  allow="geolocation; microphone; camera"
+                  src="https://form.jotform.com/252685821114355"
+                  style="width:100%; min-height: 1100px; border:0; display:block;"
+                  scrolling="no">
+                </iframe>
+
+                <noscript>
+                  <iframe
+                    title="Formulario de contacto (fallback)"
+                    src="https://form.jotform.com/252685821114355"
+                    style="width:100%; height:1400px; border:0;">
+                  </iframe>
+                </noscript>
+
+                <!-- AUTOSIZE LISTENER (RESPECTS JOTFORM MESSAGES) -->
+                <script>
+                (function () {
+                  var ifr = document.getElementById('JotFormIFrame-252685821114355');
+                  function setHeight(h){
+                    if(!ifr) return;
+                    var px = parseInt(h,10);
+                    if(!isNaN(px) && px > 400){ ifr.style.minHeight = px + 'px'; }
+                  }
+                  window.addEventListener('message', function(e){
+                    try{
+                      var data = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                      // Jotform posts objects like { "type":"setHeight","height":1234 } or "setHeight:1234"
+                      if(data && (data.type === 'setHeight' || data.message === 'setHeight')){
+                        setHeight(data.height || (data.value && data.value.height));
+                      } else if(typeof e.data === 'string' && e.data.indexOf('setHeight') > -1){
+                        var parts = e.data.split(':');
+                        setHeight(parts[1]);
+                      }
+                      // Scroll into view if Jotform requests it
+                      if(data && (data.type === 'scrollIntoView' || data.message === 'scrollIntoView')){
+                        ifr.scrollIntoView({behavior:'smooth', block:'start'});
+                      }
+                    }catch(err){/* ignore */}
+                  });
+
+                  // Safety resize on orientation change / resize
+                  ['orientationchange','resize'].forEach(function(ev){
+                    window.addEventListener(ev, function(){ setHeight(window.innerHeight + 300); });
+                  });
+                })();
+                </script>
+
 
                 <p class="small text-muted">Tratamos tus datos conforme al RGPD. Atención 9:00–20:00.</p>
               </div>
@@ -317,11 +362,11 @@
 
 <style>
   .whatsapp-float{
-    position:fixed; right:16px; bottom:16px; z-index:1030; display:inline-flex;
+    position:fixed; right:16px; bottom:24px; z-index:1030; display:inline-flex;
     align-items:center; justify-content:center; width:56px; height:56px;
     border-radius:50%; box-shadow:0 6px 18px rgba(0,0,0,.2);
   }
-  @media (min-width: 992px){ .whatsapp-float{ right:24px; bottom:24px; } }
+  @media (max-width: 576px){ .whatsapp-float{ bottom:88px; } }
 </style>
 
 </body>


### PR DESCRIPTION
## Summary
- replace each Jotform placeholder with the responsive iframe embed and autosizing listener
- add global CSS to prevent iframe clipping and adjust WhatsApp floating button spacing
- align per-page WhatsApp styles with the new mobile offset

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d6f6c75c0c832aa37f05c4700a663f